### PR TITLE
Updated the pro file to enable c++11

### DIFF
--- a/linuxdeployqt/linuxdeployqt.pro
+++ b/linuxdeployqt/linuxdeployqt.pro
@@ -1,1 +1,2 @@
 SOURCES += main.cpp ../shared/shared.cpp
+CONFIG += c++11


### PR DESCRIPTION
It refused to compile without this modification. See the errors below:

```
g++ -c -m64 -pipe -O2 -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include
/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -o shared.o ../shared/sh
ared.cpp
../shared/shared.cpp: In function ‘LddInfo findDependencyInfo(const QString&)’:
../shared/shared.cpp:166:15: warning: ‘auto’ changes meaning in C++11; please remove it [-Wc++0x-compat]
         const auto match = regexp.match(outputLines.first());
               ^
```

g++ version:
```
$ g++ --version
g++ (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
```