### PR TITLE
Improved the way Qt files are located

### DIFF
--- a/linuxdeployqt/main.cpp
+++ b/linuxdeployqt/main.cpp
@@ -38,9 +38,10 @@ int main(int argc, char **argv)
 
     QString appBinaryPath;
 
-    if (argc > 1)
+    if (argc > 1) {
         appBinaryPath = QString::fromLocal8Bit(argv[1]);
         appBinaryPath = QDir::cleanPath(appBinaryPath).trimmed();
+    }
 
     if (argc < 2 || appBinaryPath.startsWith("-")) {
         qDebug() << "Usage: linuxdeployqt app-binary [options]";
@@ -199,7 +200,8 @@ int main(int argc, char **argv)
     }
 
     if (plugins && !deploymentInfo.qtPath.isEmpty()) {
-        deploymentInfo.pluginPath = QDir::cleanPath(deploymentInfo.qtPath + "/../plugins");
+        if (deploymentInfo.pluginPath.isEmpty())
+            deploymentInfo.pluginPath = QDir::cleanPath(deploymentInfo.qtPath + "/../plugins");
         deployPlugins(appDirPath, deploymentInfo);
         createQtConf(appDirPath);
     }


### PR DESCRIPTION
Using `qmake -query` to get all information explicitly instead of parsing the output of `qmake -v` and deriving binary path, plugin path and QML path from there.

Fixes #28
Fixes #37

*Warning: while it should work, I could not test this on Ubuntu yet!*