### PR TITLE
linuxdeployqt/linuxdeployqt.pro: explicitly state linuxdeployqt's dependency on just QtCore.

### DIFF
--- a/linuxdeployqt/linuxdeployqt.pro
+++ b/linuxdeployqt/linuxdeployqt.pro
@@ -1,1 +1,2 @@
+QT = core
 SOURCES += main.cpp ../shared/shared.cpp


### PR DESCRIPTION
Qt installations without QtGui/QtWidgets still include a default
QT variable of 'core gui'.

Explicitlyt setting QT to just 'core' fixes the build on such
configurations.