### PR TITLE
Fix compile error when using Qt5.2

### DIFF
--- a/shared/shared.cpp
+++ b/shared/shared.cpp
@@ -1109,7 +1109,7 @@ bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, 
         QString path = import["path"].toString();
         QString type = import["type"].toString();
 
-        if (import["name"] == "QtQuick.Controls")
+        if (import["name"].toString() == "QtQuick.Controls")
             qtQuickContolsInUse = true;
 
         LogNormal() << "Deploying QML import" << name;


### PR DESCRIPTION
Error message was:

```
/usr/include/qt5/QtCore/qjsonvalue.h: In function 'bool deployQmlImports(const QString&, DeploymentInfo, QStringList&)':
/usr/include/qt5/QtCore/qjsonvalue.h:119:12: error: 'QJsonValue::QJsonValue(const void*)' is private
     inline QJsonValue(const void *) {}
            ^
../shared/shared.cpp:1112:31: error: within this context
         if (import["name"] == "QtQuick.Controls")
                               ^
make[1]: *** [shared.o] Error 1
```

After this change, `linuxdeployqt` also compiles with Qt5.2 (which is available on Travis-CI).