### PR TITLE
Fix wrong PATH (remove "/usr/bin" suffix)

### DIFF
--- a/linuxdeployqt/main.cpp
+++ b/linuxdeployqt/main.cpp
@@ -74,11 +74,11 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Allow binaries in the usr/bin subdirectory to be found; this is useful for bundling
+    // Allow binaries next to linuxdeployqt to be found; this is useful for bundling
     // this application itself together with helper binaries such as patchelf
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QString oldPath = env.value("PATH");
-    QString newPath = QCoreApplication::applicationDirPath()+ "/usr/bin" + ":" + oldPath;
+    QString newPath = QCoreApplication::applicationDirPath() + ":" + oldPath;
     qDebug() << newPath;
     setenv("PATH",newPath.toUtf8().constData(),1);
 


### PR DESCRIPTION
That suffix is no longer required because `linuxdeployqt` itself is now also located in that directory.

Fixes this error (see https://github.com/probonopd/linuxdeployqt/issues/65#issuecomment-280149959):
```
ERROR: Could not start patchelf.
ERROR: Make sure it is installed on your $PATH, e.g., in /usr/local/bin.
ERROR: You can get it from https://nixos.org/patchelf.html.
```