### PR TITLE
Fix failure when creating qt.conf

### DIFF
--- a/shared/shared.cpp
+++ b/shared/shared.cpp
@@ -985,7 +985,7 @@ void createQtConf(const QString &appDirPath)
                           "Qml2Imports = qml\n";
 
     QString filePath = appDirPath + "/"; // Is picked up when placed next to the main executable
-    QString fileName = appBinaryPath + "/../qt.conf";
+    QString fileName = QDir::cleanPath(appBinaryPath + "/../qt.conf");
 
     QDir().mkpath(filePath);
 


### PR DESCRIPTION
The creation of the qt.conf file has failed with following error:

```
QIODevice::write (QFile, "app.AppDir/opt/bin/app/../qt.conf"): device not open
```

This was caused by an invalid file path (appending "/../" to a file to get its parent directory is not allowed). Fixed it by cleaning the path with `QDir::cleanPath()`.