### PR TITLE
Fix two compiler warnings.

### DIFF
--- a/shared/shared.cpp
+++ b/shared/shared.cpp
@@ -219,6 +219,8 @@ int containsHowOften(QStringList haystack, QString needle) {
 
 LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, const QSet<QString> &rpaths)
 {
+    (void)rpaths;
+
     if(fhsLikeMode == false){
         bundleLibraryDirectory= "lib"; // relative to bundle
     } else {
@@ -680,6 +682,8 @@ void runStrip(const QString &binaryPath)
 
 void stripAppBinary(const QString &bundlePath)
 {
+    (void)bundlePath;
+
     runStrip(appBinaryPath);
 }
 


### PR DESCRIPTION
../shared/shared.cpp: In function ‘LibraryInfo parseLddLibraryLine(const QString&, const QString&, const QSet<QString>&)’:
../shared/shared.cpp:220:102: warning: unused parameter ‘rpaths’ [-Wunused-parameter]
 LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, const QSet<QString> &rpaths)
                                                                                                      ^~~~~~
../shared/shared.cpp: In function ‘void stripAppBinary(const QString&)’:
../shared/shared.cpp:681:36: warning: unused parameter ‘bundlePath’ [-Wunused-parameter]
 void stripAppBinary(const QString &bundlePath)
                                    ^~~~~~~~~~