### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,8 +1,8 @@
 # Building from source
 
-If you just would like to bundle your application, it is normally not necessary that you build `linuxdeployqt` yourself. Instead, download __linuxdeployqt-x86_64.AppImage__ from the [Releases](https://github.com/probonopd/linuxdeployqt/releases) page and `chmod a+x` it. This bundle, by the way, has been generated using `linuxdeployqt` itself as part of our Travis CI continuous build pipeline.
+If you just would like to bundle your application for x86_64 platforms, it is normally not necessary that you build `linuxdeployqt` yourself. Instead, download __linuxdeployqt-x86_64.AppImage__ from the [Releases](https://github.com/probonopd/linuxdeployqt/releases) page and `chmod a+x` it. This bundle, by the way, has been generated using `linuxdeployqt` itself as part of our Travis CI continuous build pipeline.
 
-So, if you still think you would like to compile from source, here are the steps:
+So, if you are on another platform (e.g. i686, ARM) or would like to compile from source, here are the steps:
 
 * Get and build linuxdeployqt e.g., using Qt 5.7.0 (you could use this [Qt Creator AppImage](https://bintray.com/probono/AppImages/QtCreator#files) for this)
 


### PR DESCRIPTION
Explicitly state that `linuxdeployqt` releases are x86_64 only.  This notice should be reworded if/when more platforms are added to the releases area.