### PR TITLE
Added path of problematic binary when dependency could not be found

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -301,6 +301,7 @@ LddInfo findDependencyInfo(const QString &binaryPath)
         // LogDebug() << "ldd outputLine:" << outputLine;
         if ((outputLine.contains("not found")) && (qtDetectionComplete == 1)){
             LogError() << "ldd outputLine:" << outputLine.replace("\t", "");
+            LogError() << "for binary:" << binaryPath;
             LogError() << "Please ensure that all libraries can be found by ldd. Aborting.";
             exit(1);
         }


### PR DESCRIPTION
Without verbose logging (which is really spammy) this information is otherwise not available, but it can be very helpful in finding out what's causing the problem.