### PR TITLE
Workaround for FHS mode for translations. related  #115

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1609,9 +1609,18 @@ void deployTranslations(const QString &appDirPath, quint64 usedQtModules)
         return;
     }
 
-    QString translationsDirPath = appDirPath + QStringLiteral("/translations");
-    LogDebug() << "Using" << translationsDirPath << "as translations directory for App";
-    LogDebug() << "Using" << qtTranslationsPath << " to search for Qt translations";
+    QString translationsDirPath;
+    if (!fhsLikeMode) {
+        translationsDirPath = appDirPath + QStringLiteral("/translations");
+    } else {
+        // TODO: refactor this global variables hack
+        QFileInfo appBinaryFI(appBinaryPath);
+        QString appRoot = appBinaryFI.absoluteDir().absolutePath() + "/../";
+        translationsDirPath = appRoot + QStringLiteral("/translations");
+    }
+
+    LogNormal() << "Using" << translationsDirPath << "as translations directory for App";
+    LogNormal() << "Using" << qtTranslationsPath << " to search for Qt translations";
 
     QFileInfo fi(translationsDirPath);
     if (!fi.isDir()) {


### PR DESCRIPTION
This is a weak attempt to fix the issue with translations generation in FHS mode. 

**PROPER** way to fix that would be to have a clear definition of "destination root" instead of `if` statements with global variables all over the code (this is just a suggestion).