### PR TITLE
deploy xcbglintegrations plugin if libxcb-glx used

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1218,7 +1218,9 @@ void deployPlugins(const AppDirInfo &appDirInfo, const QString &pluginSourcePath
     }
 
     // Platform OpenGL context
-    if ((containsHowOften(deploymentInfo.deployedLibraries, "libQt5OpenGL")) or (containsHowOften(deploymentInfo.deployedLibraries, "libQt5XcbQpa"))) {
+    if ((containsHowOften(deploymentInfo.deployedLibraries, "libQt5OpenGL"))
+		    or (containsHowOften(deploymentInfo.deployedLibraries, "libQt5XcbQpa"))
+		    or (containsHowOften(deploymentInfo.deployedLibraries, "libxcb-glx"))) {
         QStringList xcbglintegrationPlugins = QDir(pluginSourcePath +  QStringLiteral("/xcbglintegrations")).entryList(QStringList() << QStringLiteral("*.so"));
         foreach (const QString &plugin, xcbglintegrationPlugins) {
             pluginList.append(QStringLiteral("xcbglintegrations/") + plugin);


### PR DESCRIPTION
if xcbglintegrations plugin not deployed then we get
following error message when try to run AppImage application:

"QXcbIntegration: Cannot create platform OpenGL context, neither GLX nor
EGL are enabled"

we should include xcbglintegrations plugin when libxcb-glx.so found in
library list (obtained from ldd output). Some applications do not
depends on libQt5OpenGL.so but depends on libxcb-glx.so.