### PR TITLE
CMake configuration for linuxdeployqt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+# CMake configuration for linuxdeployqt
+# Not meant to replace the qmake build system, but for use with CMake based IDEs.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(linuxdeployqt)
+
+add_subdirectory(tools/linuxdeployqt)

--- a/tools/linuxdeployqt/CMakeLists.txt
+++ b/tools/linuxdeployqt/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+add_executable(linuxdeployqt main.cpp shared.cpp)
+target_include_directories(linuxdeployqt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(linuxdeployqt Qt5::Core)


### PR DESCRIPTION
Not meant to replace the qmake build system, but for use with CMake based IDEs.