### PR TITLE
Add ability to block libs in folder and specify where the deployed libs should be saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,32 @@ Please download __linuxdeployqt-x86_64.AppImage__ from the [Releases](https://gi
 ## Usage
 
 ```
-Usage: linuxdeployqt app-binary [options]
+Usage: linuxdeployqt <app-binary|desktop file> [options]
 
 Options:
-   -verbose=<0-3>        : 0 = no output, 1 = error/warning (default), 2 = normal, 3 = debug
-   -no-plugins           : Skip plugin deployment
-   -appimage             : Create an AppImage
-   -no-strip             : Don't run 'strip' on the binaries
-   -bundle-non-qt-libs   : Also bundle non-core, non-Qt libraries
-   -executable=<path>    : Let the given executable use the deployed libraries too
-   -qmldir=<path>        : Scan for QML imports to bundle from the given directory, determined by Qt's qmlimportscanner
-   -always-overwrite     : Copy files even if the target file exists
-   -qmake=<path>         : The qmake executable to use
-   -no-translations      : Skip deployment of translations
-   -extra-plugins=<list> : List of extra plugins which should be deployed, separated by comma
+   -verbose=<0-3>         : 0 = no output, 1 = error/warning (default),
+                            2 = normal, 3 = debug
+   -no-plugins            : Skip plugin deployment
+   -appimage              : Create an AppImage (implies -bundle-non-qt-libs)
+   -no-strip              : Don't run 'strip' on the binaries
+   -bundle-non-qt-libs    : Also bundle non-core, non-Qt libraries
+   -executable=<path>     : Let the given executable use the deployed libraries
+                            too
+   -qmldir=<path>         : Scan for QML imports in the given path
+   -always-overwrite      : Copy files even if the target file exists
+   -qmake=<path>          : The qmake executable to use
+   -no-translations       : Skip deployment of translations.
+   -extra-plugins=<list>  : List of extra plugins which should be deployed,
+                            separated by comma.
+   -save-lib-path         : Relative path from folder below bin to where to save the deployed libs,
+                            defaults to /lib
+   -exclude-folder:       : Excludes all libs in folder and subfolders.
+   -version               : Print version statement and exit.
 
 linuxdeployqt takes an application as input and makes it
 self-contained by copying in the Qt libraries and plugins that
 the application uses.
+
 ```
 
 #### Simplest example

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Options:
 linuxdeployqt takes an application as input and makes it
 self-contained by copying in the Qt libraries and plugins that
 the application uses.
-
 ```
 
 #### Simplest example

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -81,6 +81,9 @@ int main(int argc, char **argv)
         qInfo() << "   -no-translations       : Skip deployment of translations.";
         qInfo() << "   -extra-plugins=<list>  : List of extra plugins which should be deployed,";
         qInfo() << "                            separated by comma.";
+        qInfo() << "   -save-lib-path         : Relative path from folder below bin to where to save the deployed libs,";
+        qInfo() << "                            defaults to /lib, should not be used with -appimage";
+        qInfo() << "   -exclude-folder:       : Excludes all libs in folder and subfolders.";
         qInfo() << "   -version               : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";
@@ -369,6 +372,7 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             appimage = true;
             bundleAllButCoreLibs = true;
+            librarySavePath = "";
         } else if (argument == QByteArray("-no-strip")) {
             LogDebug() << "Argument found:" << argument;
             runStripEnabled = false;
@@ -418,9 +422,9 @@ int main(int argc, char **argv)
           int index = argument.indexOf('=');
           if (index == -1)
               LogError() << "Missing library path";
-          else
+          else if (!appimage)
               librarySavePath = argument.mid(index+1);
-        } else if (argument.startsWith(QByteArray("-exclude-libs-in-folder"))) {
+        } else if (argument.startsWith(QByteArray("-exclude-folder"))) {
           LogDebug() << "Argument found:" << argument;
           int index = argument.indexOf('=');
           if (index == -1)

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -99,10 +99,8 @@ int main(int argc, char **argv)
         qInfo() << "";
         qInfo() << "See the \"Deploying Applications on Linux\" topic in the";
         qInfo() << "documentation for more information about deployment on Linux.";
-
         return 1;
     }
-
     QString desktopFile = "";
     QString desktopExecEntry = "";
     QString desktopIconEntry = "";
@@ -199,6 +197,9 @@ int main(int argc, char **argv)
     extern bool fhsLikeMode;
     extern QString fhsPrefix;
     extern QStringList librarySearchPath;
+    extern QString librarySavePath;
+    extern QString blockedFolder;
+
     extern bool alwaysOwerwriteEnabled;    
     QStringList additionalExecutables;
     bool qmldirArgumentUsed = false;
@@ -234,6 +235,7 @@ int main(int argc, char **argv)
         QString relativePrefix = fhsPrefix.replace(appDirPath+"/", "");
         relativeBinPath = relativePrefix + "/bin/" + appName;
     }
+
     if(appDirPath == "/"){
         LogError() << "'/' is not a valid AppDir. Please refer to the documentation.";
         LogError() << "Consider adding INSTALL_ROOT or DESTDIR to your install steps.";
@@ -411,6 +413,20 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             extraQtPlugins = QString(argument.mid(index + 1)).split(",");
+        } else if (argument.startsWith(QByteArray("-save-lib-path"))) {
+          LogDebug() << "Argument found:" << argument;
+          int index = argument.indexOf('=');
+          if (index == -1)
+              LogError() << "Missing library path";
+          else
+              librarySavePath = argument.mid(index+1);
+        } else if (argument.startsWith(QByteArray("-exclude-libs-in-folder"))) {
+          LogDebug() << "Argument found:" << argument;
+          int index = argument.indexOf('=');
+          if (index == -1)
+              LogError() << "Missing exclude folder path";
+          else
+              blockedFolder = argument.mid(index+1);
         } else if (argument.startsWith("-")) {
             LogError() << "Error: arguments must not start with --, only -" << "\n";
             return 1;

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -102,8 +102,10 @@ int main(int argc, char **argv)
         qInfo() << "";
         qInfo() << "See the \"Deploying Applications on Linux\" topic in the";
         qInfo() << "documentation for more information about deployment on Linux.";
+
         return 1;
     }
+
     QString desktopFile = "";
     QString desktopExecEntry = "";
     QString desktopIconEntry = "";
@@ -202,7 +204,6 @@ int main(int argc, char **argv)
     extern QStringList librarySearchPath;
     extern QString librarySavePath;
     extern QString blockedFolder;
-
     extern bool alwaysOwerwriteEnabled;    
     QStringList additionalExecutables;
     bool qmldirArgumentUsed = false;
@@ -238,7 +239,6 @@ int main(int argc, char **argv)
         QString relativePrefix = fhsPrefix.replace(appDirPath+"/", "");
         relativeBinPath = relativePrefix + "/bin/" + appName;
     }
-
     if(appDirPath == "/"){
         LogError() << "'/' is not a valid AppDir. Please refer to the documentation.";
         LogError() << "Consider adding INSTALL_ROOT or DESTDIR to your install steps.";

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -836,6 +836,7 @@ void changeIdentification(const QString &id, const QString &binaryPath)
 {
     LogNormal() << "Checking rpath in" << binaryPath;
     QString oldRpath = runPatchelf(QStringList() << "--print-rpath" << binaryPath);
+    LogDebug() << "oldRpath:" << oldRpath;
     QString newRpath;
     if (oldRpath.startsWith("/")){
         LogDebug() << "Old rpath in" << binaryPath << "starts with /, hence adding it to LD_LIBRARY_PATH";

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -28,6 +28,7 @@
 #include <QCoreApplication>
 #include <QString>
 #include <QStringList>
+#include <QFileInfo>
 #include <QDebug>
 #include <iostream>
 #include <QProcess>
@@ -52,6 +53,8 @@ bool fhsLikeMode = false;
 QString fhsPrefix;
 bool alwaysOwerwriteEnabled = false;
 QStringList librarySearchPath;
+QString librarySavePath;
+QString blockedFolder;
 bool appstoreCompliant = false;
 int logLevel = 1;
 int qtDetected = 0;
@@ -435,12 +438,7 @@ LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, 
 {
     (void)rpaths;
 
-    if(fhsLikeMode == false){
-        bundleLibraryDirectory= "lib"; // relative to bundle
-    } else {
-        QString relativePrefix = fhsPrefix.replace(appDirPath+"/", "");
-        bundleLibraryDirectory = relativePrefix + "/lib/";
-    }
+    handleFshLibPath(appDirPath);
     LogDebug() << "bundleLibraryDirectory:" << bundleLibraryDirectory;
 
     LibraryInfo info;
@@ -465,12 +463,11 @@ LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, 
           echo -ne '"'$item'" << '
         done
         */
-
         QStringList excludelist;
         excludelist << "libasound.so.2" << "libcom_err.so.2" << "libcrypt.so.1" << "libc.so.6" << "libdl.so.2" << "libdrm.so.2" << "libexpat.so.1" << "libfontconfig.so.1" << "libgcc_s.so.1" << "libgdk_pixbuf-2.0.so.0" << "libgio-2.0.so.0" << "libglib-2.0.so.0" << "libGL.so.1" << "libgobject-2.0.so.0" << "libgpg-error.so.0" << "libICE.so.6" << "libkeyutils.so.1" << "libm.so.6" << "libnsl.so.1" << "libnss3.so" << "libnssutil3.so" << "libp11-kit.so.0" << "libpangoft2-1.0.so.0" << "libpangocairo-1.0.so.0" << "libpango-1.0.so.0" << "libpthread.so.0" << "libresolv.so.2" << "librt.so.1" << "libSM.so.6" << "libstdc++.so.6" << "libusb-1.0.so.0" << "libuuid.so.1" << "libX11.so.6" << "libxcb.so.1" << "libz.so.1";
         LogDebug() << "excludelist:" << excludelist;
         if (! trimmed.contains("libicu")) {
-            if (containsHowOften(excludelist, QFileInfo(trimmed).completeBaseName())) {
+            if (containsHowOften(excludelist, QFileInfo(trimmed).completeBaseName()) || QFileInfo(trimmed).absolutePath().startsWith(blockedFolder)) {
                 LogDebug() << "Skipping blacklisted" << trimmed;
                 return info;
             }
@@ -556,6 +553,7 @@ LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, 
     }
 
     if (!info.sourceFilePath.isEmpty() && QFile::exists(info.sourceFilePath)) {
+      qInfo() << "TJA";
         info.installName = findDependencyInfo(info.sourceFilePath).installName;
         if (info.installName.startsWith("@rpath/"))
             info.deployedInstallName = info.installName;
@@ -716,13 +714,7 @@ void recursiveCopyAndDeploy(const QString &appDirPath, const QSet<QString> &rpat
             runStrip(fileDestinationPath);
 
             // Find out the relative path to the lib/ directory and set it as the rpath
-            // FIXME: remove code duplication - the next few lines exist elsewhere already
-            if(fhsLikeMode == false){
-                bundleLibraryDirectory= "lib"; // relative to bundle
-            } else {
-                QString relativePrefix = fhsPrefix.replace(appDirPath+"/", "");
-                bundleLibraryDirectory = relativePrefix + "/lib/";
-            }
+            handleFshLibPath(appDirPath);
 
             QDir dir(QFileInfo(fileDestinationPath).canonicalFilePath());
             QString relativePath = dir.relativeFilePath(appDirPath + "/" + bundleLibraryDirectory);
@@ -845,7 +837,7 @@ void changeIdentification(const QString &id, const QString &binaryPath)
 {
     LogNormal() << "Checking rpath in" << binaryPath;
     QString oldRpath = runPatchelf(QStringList() << "--print-rpath" << binaryPath);
-    LogDebug() << "oldRpath:" << oldRpath;
+//if(oldRpath.startsWith("$")) return;
     if (oldRpath.startsWith("/")){
         LogDebug() << "Old rpath in" << binaryPath << "starts with /, hence adding it to LD_LIBRARY_PATH";
         // FIXME: Split along ":" characters, check each one, only append to LD_LIBRARY_PATH if not already there
@@ -858,8 +850,8 @@ void changeIdentification(const QString &id, const QString &binaryPath)
             setenv("LD_LIBRARY_PATH",newPath.toUtf8().constData(),1);
         }
     }
-    LogNormal() << "Changing rpath in" << binaryPath << "to" << id;
-    runPatchelf(QStringList() << "--set-rpath" << id << binaryPath);
+    LogNormal() << "Changing rpath in" << binaryPath << "to" <<  id;
+    runPatchelf(QStringList() << "--set-rpath" <<  id << binaryPath);
 
     // qt_prfxpath:
     if (binaryPath.contains("libQt5Core")) {
@@ -1866,3 +1858,26 @@ bool deployTranslations(const QString &sourcePath, const QString &target, quint6
     } // for prefixes.
     return true;
 }
+
+
+void handleFshLibPath(const QString& appDirPath)
+{
+  if(fhsLikeMode == false){
+      bundleLibraryDirectory = librarySavePath.isEmpty() ? "lib" : librarySavePath; // relative to bundle
+   } else {
+       QString relativePrefix = fhsPrefix.replace(appDirPath+"/", "");
+       bundleLibraryDirectory = relativePrefix + "/" + librarySavePath;
+   }
+}
+
+QString stripAbsolutePathFromRPath(QString& rpath)
+{
+  QString ret;
+  QChar divider = ':';
+  QStringList subPaths = rpath.split(divider);
+  for(QString sub : subPaths) {
+    if(!sub.startsWith("/")) ret += divider + sub;
+  }
+  return ret;
+}
+

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -136,6 +136,5 @@ void findUsedModules(DeploymentInfo &info);
 void deployTranslations(const QString &appDirPath, quint64 usedQtModules);
 bool deployTranslations(const QString &sourcePath, const QString &target, quint64 usedQtModules);
 void handleFshLibPath(const QString& appDirPath);
-QString stripAbsolutePathFromRPath(QString& rPath);
 
 #endif

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -135,5 +135,7 @@ bool checkAppImagePrerequisites(const QString &appBundlePath);
 void findUsedModules(DeploymentInfo &info);
 void deployTranslations(const QString &appDirPath, quint64 usedQtModules);
 bool deployTranslations(const QString &sourcePath, const QString &target, quint64 usedQtModules);
+void handleFshLibPath(const QString& appDirPath);
+QString stripAbsolutePathFromRPath(QString& rPath);
 
 #endif


### PR DESCRIPTION
Needed to add some functionality to match our needs and thought that someone else might want the same functionality.

So to understand why this functionality might be needed I'll give an example.
If you have a ecosystem with several apps that share some libraries looking like this:
Ecosystem
|--AppA
|    |--bin
|    |    |--AppA
|    |--lib
|    |     |--libA.so
|--AppB
|    |--bin
|    |     |--AppB
|    | -lib
|    |     |--libB.so
| --Core
|    | --lib
|    |     |--libCore.so

Both AppA and AppB have a dependency towards libCore.so, to the libs inside the lib-folder and against other libs like Qt.
To not deploy Qt once for each app we instead want to be able to create a folder inside the folder Ecosystem named lib or systemlibs and deploy all libs in this folder. This is added by the "save-lib-path" flag where you specify the relative path from the folder below the binary path.

And to keep the lib structure clean and divided we want to be able to say that libs that lies inside the Ecosystem shouldn't be deployed, this demands that the programmer have fixed the Rpath of the bin before running the program and then the new folder with all the newly deployed libs will be appended to Rpath using $ORIGIN. This is added by "-exclude-folder" that take a absolute path to a folder and any libs inside it won't be deployed.

This might just be something that we need on our code base, but sharing i caring! 