### PR TITLE
Add new '-no-copy-copyright-files' option to increase a performance

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
         qInfo() << "Options:";
         qInfo() << "   -verbose=<0-3>         : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                            2 = normal, 3 = debug";
+        qInfo() << "   -no-copyright          : Don't copy copyright files (increased a speed)";
         qInfo() << "   -no-plugins            : Skip plugin deployment";
         qInfo() << "   -appimage              : Create an AppImage (implies -bundle-non-qt-libs)";
         qInfo() << "   -no-strip              : Don't run 'strip' on the binaries";
@@ -194,6 +195,7 @@ int main(int argc, char **argv)
 
     bool plugins = true;
     bool appimage = false;
+    extern bool copyCopyrightEnabled;
     extern bool runStripEnabled;
     extern bool bundleAllButCoreLibs;
     extern bool fhsLikeMode;
@@ -360,7 +362,10 @@ int main(int argc, char **argv)
 
     for (int i = 2; i < argc; ++i) {
         QByteArray argument = QByteArray(argv[i]);
-        if (argument == QByteArray("-no-plugins")) {
+        if (argument == QByteArray("-no-copyright")) {
+            LogDebug() << "Argument found:" << argument;
+            copyCopyrightEnabled = false;
+        } else if (argument == QByteArray("-no-plugins")) {
             LogDebug() << "Argument found:" << argument;
             plugins = false;
         } else if (argument == QByteArray("-appimage")) {

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -46,6 +46,7 @@
 #include "shared.h"
 
 QString appBinaryPath;
+bool copyCopyrightEnabled = true;
 bool runStripEnabled = true;
 bool bundleAllButCoreLibs = false;
 bool fhsLikeMode = false;
@@ -276,7 +277,10 @@ bool copyFilePrintStatus(const QString &from, const QString &to)
     }
 }
 
-bool copyCopyrightFile(QString libPath){
+bool copyCopyrightFile(QString libPath)
+{
+    if (!copyCopyrightEnabled)
+        return true;
 
     /* When deploying files (e.g., libraries) from the
      * system, then try to also deploy their copyright file.

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -41,6 +41,7 @@ extern int logLevel;
 #define LogDebug()      if (logLevel < 3) {} else qDebug() << "Log:"
 
 extern QString appBinaryPath;
+extern bool copyCopyrightEnabled;
 extern bool runStripEnabled;
 extern bool bundleAllButCoreLibs;
 extern bool fhsLikeMode;


### PR DESCRIPTION
This option disables copying of "copyright" files through dpkg utility,
which is available only on Debian-based distros. With this option a
spent time for handling of one application decreases from ~15 minutes up
to 15 seconds, e.g. if a user's project uses QML imports.

Task-number: #231