### PR TITLE
Added support for -excludeLibs command line option

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -82,6 +82,8 @@ int main(int argc, char **argv)
         qInfo() << "   -no-copy-copyright-files : Skip deployment of copyright files.";
         qInfo() << "   -extra-plugins=<list>    : List of extra plugins which should be deployed,";
         qInfo() << "                              separated by comma.";
+        qInfo() << "   -exclude-libs=<list>     : List of extra plugins which should be deployed,";
+        qInfo() << "                              separated by comma.";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";
@@ -207,6 +209,7 @@ int main(int argc, char **argv)
     QStringList qmlDirs;
     QString qmakeExecutable;
     extern QStringList extraQtPlugins;
+    extern QStringList excludeLibs;
     extern bool copyCopyrightFiles;
 
     /* FHS-like mode is for an application that has been installed to a $PREFIX which is otherwise empty, e.g., /path/to/usr.
@@ -416,6 +419,10 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             extraQtPlugins = QString(argument.mid(index + 1)).split(",");
+        } else if (argument.startsWith("-exclude-libs=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            excludeLibs = QString(argument.mid(index + 1)).split(",");
         } else if (argument.startsWith("-")) {
             LogError() << "Error: arguments must not start with --, only -" << "\n";
             return 1;

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -439,6 +439,11 @@ int main(int argc, char **argv)
         }
     }
 
+    if (!excludeLibs.isEmpty())
+    {
+        qWarning() << "WARNING: Excluding the following libraries might break the AppImage. Please double-check the list:" << excludeLibs;
+    }
+
     DeploymentInfo deploymentInfo = deployQtLibraries(appDirPath, additionalExecutables,
                                                       qmakeExecutable);
 

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
         qInfo() << "   -no-copy-copyright-files : Skip deployment of copyright files.";
         qInfo() << "   -extra-plugins=<list>    : List of extra plugins which should be deployed,";
         qInfo() << "                              separated by comma.";
-        qInfo() << "   -exclude-libs=<list>     : List of extra plugins which should be deployed,";
+        qInfo() << "   -exclude-libs=<list>     : List of libraries which should be excluded,";
         qInfo() << "                              separated by comma.";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -46,6 +46,7 @@ extern bool bundleAllButCoreLibs;
 extern bool fhsLikeMode;
 extern QString fhsPrefix;
 extern QStringList extraQtPlugins;
+extern QStringList excludeLibs;
 
 class LibraryInfo
 {


### PR DESCRIPTION
This helps us avoid pesky libraries which are optional by the main
binary but may be dragged in by some other libraries like
https://github.com/probonopd/linuxdeployqt/issues/235

Usage: -exclude-libs=libqsqlibase,libqsqlodbc,libqsqlpsql,libqsqltds