### PR TITLE
Improve argument parser user experience

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -416,11 +416,11 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             extraQtPlugins = QString(argument.mid(index + 1)).split(",");
-        } else if (argument.startsWith("-")) {
-            LogError() << "Error: arguments must not start with --, only -" << "\n";
+        } else if (argument.startsWith("--")) {
+            LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;
         } else {
-            LogError() << "Unknown argument" << argument << "\n";
+            LogError() << "Unknown argument:" << argument << "\n";
             return 1;
         }
      }


### PR DESCRIPTION
See https://github.com/probonopd/linuxdeployqt/issues/256#issuecomment-373916136

The argument parser requires flags expecting a payload to be passed in
the form -arg=payload. If not, it fails to recognize them and falsely
reports "argument must not start with --". These usability issues
should be gone with these two minor changes.