### PR TITLE
Fix generate-excludelist.sh for Bash 4.1

### DIFF
--- a/tools/generate-excludelist.sh
+++ b/tools/generate-excludelist.sh
@@ -37,6 +37,6 @@ EOF
 for item in ${blacklisted[@]:0:${#blacklisted[@]}-1}; do
     echo -e '    "'"$item"'",' >> "$filename"
 done
-echo -e '    "'"${blacklisted[-1]}"'"' >> "$filename"
+echo -e '    "'"${blacklisted[$((${#blacklisted[@]}-1))]}"'"' >> "$filename"
 
 echo "};" >> "$filename"


### PR DESCRIPTION
Bash 4.1 does not support a -1 array subscript. Compute the last index instead.