### PR TITLE
add the xcbglintegrations plugin when using libQt5Gui.

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1225,6 +1225,7 @@ void deployPlugins(const AppDirInfo &appDirInfo, const QString &pluginSourcePath
 
     // Platform OpenGL context
     if ((containsHowOften(deploymentInfo.deployedLibraries, "libQt5OpenGL"))
+		    or (containsHowOften(deploymentInfo.deployedLibraries, "libQt5Gui"))
 		    or (containsHowOften(deploymentInfo.deployedLibraries, "libQt5XcbQpa"))
 		    or (containsHowOften(deploymentInfo.deployedLibraries, "libxcb-glx"))) {
         QStringList xcbglintegrationPlugins = QDir(pluginSourcePath +  QStringLiteral("/xcbglintegrations")).entryList(QStringList() << QStringLiteral("*.so"));


### PR DESCRIPTION
This resolves #30 for me, see my comments there.   It may assume that the dependency platforms/libqxcb.so which is added when we have libQt5Gui will introduce a dependency on libQt5XcbQpa, which already triggers xcbglintegrations.