### PR TITLE
add ability to exclude libs from a user specified list of folders.

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -77,6 +77,8 @@ int main(int argc, char **argv)
         qInfo() << "   -bundle-non-qt-libs      : Also bundle non-core, non-Qt libraries.";
         qInfo() << "   -exclude-libs=<list>     : List of libraries which should be excluded,";
         qInfo() << "                              separated by comma.";
+        qInfo() << "   -exclude-folders=<list>  : Excludes all libs in any folder (or subfolder)";
+        qInfo() << "                              in the comma separated list.";
         qInfo() << "   -executable=<path>       : Let the given executable use the deployed libraries";
         qInfo() << "                              too";
         qInfo() << "   -extra-plugins=<list>    : List of extra plugins which should be deployed,";
@@ -216,6 +218,7 @@ int main(int argc, char **argv)
     QString qmakeExecutable;
     extern QStringList extraQtPlugins;
     extern QStringList excludeLibs;
+    extern QStringList blockedFolders;
     extern bool copyCopyrightFiles;
 
     /* FHS-like mode is for an application that has been installed to a $PREFIX which is otherwise empty, e.g., /path/to/usr.
@@ -431,6 +434,10 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             excludeLibs = QString(argument.mid(index + 1)).split(",");
+        } else if (argument.startsWith("-exclude-folders=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            blockedFolders = QString(argument.mid(index + 1)).split(",");
         } else if (argument.startsWith("--")) {
             LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -60,6 +60,7 @@ bool qtDetectionComplete = 0; // As long as Qt is not detected yet, ldd may enco
 bool deployLibrary = false;
 QStringList extraQtPlugins;
 QStringList excludeLibs;
+QStringList blockedFolders;
 bool copyCopyrightFiles = true;
 
 using std::cout;
@@ -463,6 +464,11 @@ LibraryInfo parseLddLibraryLine(const QString &line, const QString &appDirPath, 
         if (!trimmed.contains("libicu") && !trimmed.contains("lib/libQt") && !trimmed.contains("lib/libqgsttools")) {
             if ((trimmed.startsWith("/usr") or (trimmed.startsWith("/lib")))) {
                 return info;
+            }
+            for (int i = 0; i < blockedFolders.size(); ++i) {
+                if (trimmed.startsWith(blockedFolders.at(i))) {
+                    return info;
+                }
             }
         }
     }

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -47,6 +47,7 @@ extern bool fhsLikeMode;
 extern QString fhsPrefix;
 extern QStringList extraQtPlugins;
 extern QStringList excludeLibs;
+extern QStringList blockedFolders;
 
 class LibraryInfo
 {


### PR DESCRIPTION
This accomplishes one of the goals of #242 in a more generalized way.  It allows a list of folder names to be given instead of a single folder.

This is useful to me when using snapcraft on a Qt based project.  By using this new option with the values:
-exclude-folders=$SNAPCRAFT_PART_INSTALL,/snap/core
linuxdeployqt will excluded libraries from the core and libraries from packages added with stage-packages which are in $SNAPCRAFT_PART_INSTALL during the build.  The libraries from /snap/core won't be included in the snap.  The libraries from any staged packages will be in the snap, but snapcraft will deal with them.  linuxdeployqt deals only with all the Qt bits.  

To get this to work for snapcraft the Qt bits must have been staged by another part that is built before the part using linuxdeployqt.  This is necessary so they are not in $SNAPCRAFT_PART_INSTALL for the part using linuxdeployqt, but they will be in $SNAPCRAFT_STAGE.