### PR TITLE
Fix the copy of the removed file.

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -219,7 +219,7 @@ inline QDebug operator<<(QDebug debug, const AppDirInfo &info)
 bool copyFilePrintStatus(const QString &from, const QString &to)
 {
     if (QFile(to).exists()) {
-        if (alwaysOwerwriteEnabled) {
+        if (alwaysOwerwriteEnabled && QFileInfo(to) != QFileInfo(from)) {
             QFile(to).remove();
         } else {
             LogDebug() << QFileInfo(to).fileName() << "already exists at target location";


### PR DESCRIPTION
This commit is reaction to this [issue](https://github.com/probonopd/linuxdeployqt/issues/246#issuecomment-393938207).

The error occurs when both the destination (to) and the copy source (from) are the same and alwaysOwerwriteEnabled is true. In this case, you are trying to copy the file which is deleted it on line 222.

Checking that the files are different is sufficient to correct this error. I would consider logging into LogDebug.