### PR TITLE
Add --force-rpath to patchelf invocation

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -838,7 +838,7 @@ void changeIdentification(const QString &id, const QString &binaryPath)
         }
     }
     LogNormal() << "Changing rpath in" << binaryPath << "to" << id;
-    runPatchelf(QStringList() << "--set-rpath" << id << binaryPath);
+    runPatchelf(QStringList() << "--set-rpath" << id << "--force-rpath" << binaryPath);
 
     // qt_prfxpath:
     if (binaryPath.contains("libQt5Core")) {


### PR DESCRIPTION
It looks like the patchelf invocation has not actually been setting the rpath, but the runpath, which can be overridden under some circumstances.