### PR TITLE
Add -ignore-glob argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Options:
    -bundle-non-qt-libs      : Also bundle non-core, non-Qt libraries.
    -exclude-libs=<list>     : List of libraries which should be excluded,
                               separated by comma.
+   -ignore-glob=<glob>      : Glob pattern relative to appdir to ignore when
+                              searching for libraries.
    -executable=<path>       : Let the given executable use the deployed libraries
                               too
    -extra-plugins=<list>    : List of extra plugins which should be deployed,

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -77,6 +77,8 @@ int main(int argc, char **argv)
         qInfo() << "   -bundle-non-qt-libs      : Also bundle non-core, non-Qt libraries.";
         qInfo() << "   -exclude-libs=<list>     : List of libraries which should be excluded,";
         qInfo() << "                              separated by comma.";
+        qInfo() << "   -ignore-glob=<glob>      : Glob pattern relative to appdir to ignore when";
+        qInfo() << "                              searching for libraries.";
         qInfo() << "   -executable=<path>       : Let the given executable use the deployed libraries";
         qInfo() << "                              too";
         qInfo() << "   -extra-plugins=<list>    : List of extra plugins which should be deployed,";
@@ -216,6 +218,7 @@ int main(int argc, char **argv)
     QString qmakeExecutable;
     extern QStringList extraQtPlugins;
     extern QStringList excludeLibs;
+    extern QStringList ignoreGlob;
     extern bool copyCopyrightFiles;
 
     /* FHS-like mode is for an application that has been installed to a $PREFIX which is otherwise empty, e.g., /path/to/usr.
@@ -431,6 +434,10 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             excludeLibs = QString(argument.mid(index + 1)).split(",");
+        } else if (argument.startsWith("-ignore-glob=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            ignoreGlob += argument.mid(index + 1);
         } else if (argument.startsWith("--")) {
             LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;


### PR DESCRIPTION
We are shipping a whole build of python inside the AppImage in https://github.com/radareorg/cutter, including some packages installed with pip, which come with a few shared libraries under /usr/lib/python3.6/site-packages that are loaded dynamically and should not be touched by linuxdeployqt.

-exclude-libs is not really an option for us since we don't necessarily know the exact filenames of the libraries, so we now use `-ignore-glob=usr/lib/python3.6/**`, which gets the job done.