### PR TITLE
Add option to specify qmlimportscanner importPaths

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -89,6 +89,7 @@ int main(int argc, char **argv)
         qInfo() << "   -no-translations         : Skip deployment of translations.";
         qInfo() << "   -qmake=<path>            : The qmake executable to use.";
         qInfo() << "   -qmldir=<path>           : Scan for QML imports in the given path.";
+        qInfo() << "   -qmlimport=<path>        : Add the given path to QML module search locations.";
         qInfo() << "   -show-exclude-libs       : Print exclude libraries list.";
         qInfo() << "   -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                              2 = normal, 3 = debug.";
@@ -215,6 +216,7 @@ int main(int argc, char **argv)
     bool qmldirArgumentUsed = false;
     bool skipTranslations = false;
     QStringList qmlDirs;
+    QStringList qmlImportPaths;
     QString qmakeExecutable;
     extern QStringList extraQtPlugins;
     extern QStringList excludeLibs;
@@ -413,6 +415,13 @@ int main(int argc, char **argv)
                 LogError() << "Missing qml directory path";
             else
                 qmlDirs << argument.mid(index+1);
+        } else if (argument.startsWith(QByteArray("-qmlimport"))) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf('=');
+            if (index == -1)
+                LogError() << "Missing qml import path";
+            else
+                qmlImportPaths << argument.mid(index+1);
         } else if (argument.startsWith("-no-copy-copyright-files")) {
             LogDebug() << "Argument found:" << argument;
             copyCopyrightFiles = false;
@@ -471,7 +480,7 @@ int main(int argc, char **argv)
     }
 
     if (!qmlDirs.isEmpty()) {
-        bool ok = deployQmlImports(appDirPath, deploymentInfo, qmlDirs);
+        bool ok = deployQmlImports(appDirPath, deploymentInfo, qmlDirs, qmlImportPaths);
         if (!ok && qmldirArgumentUsed)
             return 1; // exit if the user explicitly asked for qml import deployment
         // Update deploymentInfo.deployedLibraries - the QML imports

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1522,7 +1522,7 @@ void deployQmlImport(const QString &appDirPath, const QSet<QString> &rpaths, con
 }
 
 // Scan qml files in qmldirs for import statements, deploy used imports from Qml2ImportsPath to ./qml.
-bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, QStringList &qmlDirs)
+bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, QStringList &qmlDirs, QStringList &qmlImportPaths)
 {
     if(!qtDetected){
         LogDebug() << "Skipping QML imports since no Qt detected";
@@ -1531,7 +1531,8 @@ bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, 
 
     LogNormal() << "";
     LogNormal() << "Deploying QML imports ";
-    LogNormal() << "Application QML file search path(s) is" << qmlDirs;
+    LogNormal() << "Application QML file path(s) is" << qmlDirs;
+    LogNormal() << "QML module search path(s) is" << qmlImportPaths;
 
     // Use qmlimportscanner from QLibraryInfo::BinariesPath
     QString qmlImportScannerPath = QDir::cleanPath(qtToBeBundledInfo.value("QT_INSTALL_BINS")) + "/qmlimportscanner";
@@ -1556,6 +1557,11 @@ bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, 
     foreach (const QString &qmlDir, qmlDirs) {
         argumentList.append("-rootPath");
         argumentList.append(qmlDir);
+    }
+
+    foreach (const QString &importPath, qmlImportPaths) {
+        argumentList.append("-importPath");
+        argumentList.append(importPath);
     }
 
     argumentList.append( "-importPath");

--- a/tools/linuxdeployqt/shared.h
+++ b/tools/linuxdeployqt/shared.h
@@ -123,7 +123,7 @@ DeploymentInfo deployQtLibraries(QList<LibraryInfo> libraries,const QString &bun
 void createQtConf(const QString &appDirPath);
 void createQtConfForQtWebEngineProcess(const QString &appDirPath);
 void deployPlugins(const QString &appDirPath, DeploymentInfo deploymentInfo);
-bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, QStringList &qmlDirs);
+bool deployQmlImports(const QString &appDirPath, DeploymentInfo deploymentInfo, QStringList &qmlDirs, QStringList &qmlImportPaths);
 void changeIdentification(const QString &id, const QString &binaryPath);
 void changeInstallName(const QString &oldName, const QString &newName, const QString &binaryPath);
 void runStrip(const QString &binaryPath);


### PR DESCRIPTION
This commit addresses issue #319 by adding a new optional argument, `-qmlimport`, which passes QML module search locations to `qmlimportscanner`.