### PR TITLE
Also deploy Qt 4 translations, closes #360

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1868,7 +1868,7 @@ bool deployTranslations(const QString &sourcePath, const QString &target, quint6
     // Find available languages prefixes by checking on qtbase.
     QStringList prefixes;
     QDir sourceDir(sourcePath);
-    const QStringList qmFilter = QStringList(QStringLiteral("qtbase_*.qm"));
+    const QStringList qmFilter = QStringList(QStringLiteral("qt*.qm"));
     foreach (QString qmFile, sourceDir.entryList(qmFilter)) {
         qmFile.chop(3);
         qmFile.remove(0, 7);


### PR DESCRIPTION
@megastallman wrote

> the qtbase_*.qm template doesn't match the QT4 translation file names, which look like "qt_uk.qm" and "qt_help_uk.qm"

https://github.com/probonopd/linuxdeployqt/issues/360#issuecomment-487554671