### PR TITLE
Adds the option to pass custom update information

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
    -show-exclude-libs       : Print exclude libraries list.
    -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),
                               2 = normal, 3 = debug.
+   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file
    -version                 : Print version statement and exit.
 
 linuxdeployqt takes an application as input and makes it

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -73,6 +73,7 @@ int main(int argc, char **argv)
     extern QStringList excludeLibs;
     extern QStringList ignoreGlob;
     extern bool copyCopyrightFiles;
+    extern QString updateInformation;
 
     // Check arguments
     // Due to the structure of the argument parser, we have to check all arguments at first to check whether the user
@@ -168,6 +169,10 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             ignoreGlob += argument.mid(index + 1);
+        } else if (argument.startsWith("-updateinformation=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            updateInformation = QString(argument.mid(index+1));
         } else if (argument.startsWith("--")) {
             LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;
@@ -225,6 +230,7 @@ int main(int argc, char **argv)
         qInfo() << "   -show-exclude-libs       : Print exclude libraries list.";
         qInfo() << "   -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                              2 = normal, 3 = debug.";
+        qInfo() << "   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -63,6 +63,7 @@ QStringList extraQtPlugins;
 QStringList excludeLibs;
 QStringList ignoreGlob;
 bool copyCopyrightFiles = true;
+QString updateInformation;
 
 using std::cout;
 using std::endl;
@@ -1777,7 +1778,17 @@ bool checkAppImagePrerequisites(const QString &appDirPath)
 
 int createAppImage(const QString &appDirPath)
 {
-    QString appImageCommand = "appimagetool '" + appDirPath + "' -n -g"; // +"' '" + appImagePath + "'";
+    QString updateInfoArgument;
+
+    if (updateInformation.isEmpty()) {
+        // if there is no user-supplied update info, guess
+        updateInfoArgument = "-g";
+    } else {
+        updateInfoArgument = QString("-u '%1'").arg(updateInformation);
+    }
+
+    QString appImageCommand = "appimagetool -v '" + appDirPath + "' -n " + updateInfoArgument; // +"' '" + appImagePath + "'";
+    LogNormal() << appImageCommand;
     int ret = system(appImageCommand.toUtf8().constData());
     LogNormal() << "ret" << ret;
     LogNormal() << "WEXITSTATUS(ret)" << WEXITSTATUS(ret);


### PR DESCRIPTION
If linuxdeployqt is called with the option -updateinformation=<update
string>, it passes that update string to appimagetool. Otherwise it uses
-g to guess (the original behavior).