### PR TITLE
Additional check

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -459,7 +459,7 @@ int main(int argc, char **argv)
          * -unsupported-allow-new-glibc option is not abused to create results that are broken; see
          * https://github.com/probonopd/linuxdeployqt/issues/340 for more information
          * TODO: Add funtionality that would automatically bundle glibc fully and correctly in this case */
-        if(QFileInfo(skipGlibcCheck == true){
+        if(skipGlibcCheck == true){
             if(QFileInfo(appDirPath + "/usr/share/doc/libc6/copyright").exists() == false) exit(1);
         }
 

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -455,6 +455,14 @@ int main(int argc, char **argv)
             }
         }
 
+        /* Additional check to make sure that the undocumented, unsupported and not recommended
+         * -unsupported-allow-new-glibc option is not abused to create results that are broken; see
+         * https://github.com/probonopd/linuxdeployqt/issues/340 for more information
+         * TODO: Add funtionality that would automatically bundle glibc fully and correctly in this case */
+        if(QFileInfo(skipGlibcCheck == true){
+            if(QFileInfo(appDirPath + "/usr/share/doc/libc6/copyright").exists() == false) exit(1);
+        }
+
         /* Copy in place */
         if(iconToBeUsed != ""){
             /* Check if there is already an icon and only if there is not, copy it to the AppDir.


### PR DESCRIPTION
Additional check to make sure that the undocumented, unsupported and not recommended `-unsupported-allow-new-glibc` option is not abused to create results that are broken; see https://github.com/probonopd/linuxdeployqt/issues/340 for more information.

We don't want stuff like https://github.com/altairwei/conan-linuxdeployqt/blob/c4dc78d2218362388691778decde2fc893c2033f/test_package/conanfile.py#L17 to proliferate.