### PR TITLE
Add additional check on link creation

### DIFF
--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -381,7 +381,9 @@ int main(int argc, char **argv)
     if(appRun.exists()){
         qDebug() << "Keeping existing AppRun";
     } else {
-        QFile::link(relativeBinPath, appDirPath + "/AppRun");
+        if (!QFile::link(relativeBinPath, appDirPath + "/AppRun")) {
+            LogError() << "Could not create AppRun link";
+        }
     }
 
     /* Copy the desktop file in place, into the top level of the AppDir */


### PR DESCRIPTION
This pull request adds a check if the [`QFile::link()`](https://doc.qt.io/qt-5/qfile.html#link-1) is successful.
On failure, the error message is logged.

This explicit check could be useful in certain circumstances: for example, using a virtual environment (e.g. Vagrant) could lead to an inability to create a link due to the unconfigured file system synchronization.