### PR TITLE
GitHub template project using linuxdeployqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ These projects are already using [Travis CI](http://travis-ci.org/) and linuxdep
 This project is already using linuxdeployqt in a custom Jenkins workflow:
 - https://github.com/appimage-packages/
 
+This GitHub template invokes linuxdeployqt during a GitHub CI Action:
+- https://github.com/219-design/qt-qml-project-template-with-ci
+
 These projects are already using linuxdeployqt:
 - Autodesk EAGLE for Linux http://www.autodesk.com/products/eagle/free-download
 - https://github.com/bjorn/tiled/


### PR DESCRIPTION
Thank you for `linuxdeployqt`. It beats the heck out of scripting a bunch of `chrpath` calls myself (and then tweaking said script for each new project that I deploy).

Uploading this PR to share my happiness not only over `linuxdeployqt`, but over the "added synergy" of using it in conjunction with recent GitHub feature additions: actions, and template repositories.

I don't know your policies for inclusion into the "Projects using linuxdeployqt" list.  I'm totally prepared to accept whatever :+1: or :-1: verdict you issue here. No worries.

Maybe this will inspire other people to incorporate `linuxdeployqt` into their teams' template repositories.