### PR TITLE
Provide dummy Categories in default desktop file

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1758,6 +1758,7 @@ bool checkAppImagePrerequisites(const QString &appDirPath)
         out << "Icon=default\n";
         out << "Comment=Edit this default file\n";
         out << "Terminal=true\n";
+        out << "Categories=\n";
         file.close();
     }
 


### PR DESCRIPTION
While it is better to let the user provide a desktop file, it surely is not intended to provide a default desktop file that makes the build fail. Currently the default desktop file will fail the build:

```
Categories entry not found in desktop file
.desktop file is missing a Categories= key
```

I first considered putting `Categories=Qt;`, but this tool can be used for non-Qt applications as well, so I just left it blank.

This also properly fixes #383 now.