### PR TITLE
CMake - add install target

### DIFF
--- a/tools/linuxdeployqt/CMakeLists.txt
+++ b/tools/linuxdeployqt/CMakeLists.txt
@@ -28,3 +28,5 @@ add_executable(linuxdeployqt main.cpp shared.cpp)
 target_include_directories(linuxdeployqt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(linuxdeployqt Qt5::Core)
 target_compile_definitions(linuxdeployqt PRIVATE -DEXCLUDELIST="${EXCLUDELIST}")
+
+install(TARGETS linuxdeployqt)


### PR DESCRIPTION
`make install` isn't available for CMake builds. Command according to the README:

```
$ make DESTDIR=appdir -j$(nproc) install ; find appdir/
make: *** No rule to make target 'install'.  Stop.
```
