### PR TITLE
Add -qtlibinfix support in order to precise the libinfix set for a custom Qt distribution. Without this option, linuxdeployqt is not able to look at the Qt plugins directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Usage examples:
 
 #### Handle Qt libraries infix
 
-If you prepared a custom Qt distribution using the option `-qtlibinfix` during Qt configuration, you must mention this infix on `linuxdeployqt` call. As an example, let's see if we configure our distribution using the infix `Custom`.
+If you prepared a custom Qt distribution using the option `-qtlibinfix` during Qt configuration (resulting in library names such as `libQt5CoreCustom.so`), you must mention this infix on `linuxdeployqt` call. As an example, let's see if we configure our distribution using the infix `Custom`.
 
 On Qt build chain: `configure -qtlibinfix "Custom" [...]`. This will generate Qt libraries (.so) like `libQt5CoreCustom.so`
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ Usage examples:
 2. `-extra-plugins=sqldrivers,iconengines/libqsvgicon.so`  
 3. `-extra-plugins=sqldrivers,iconengines,mediaservice,gamepads`
 
+#### Handle Qt libraries infix
+
+If you prepared a custom Qt distribution using the option `-qtlibinfix` during Qt configuration, you must mention this infix on `linuxdeployqt` call. As an example, let's see if we configure our distribution using the infix `Custom`.
+
+On Qt build chain: `configure -qtlibinfix "Custom" [...]`. This will generate Qt libraries (.so) like `Qt5CoreCustom.so`
+
+So, on `linuxdeployqt` call: `linuxdeployqt [...] -qtlibinfix "Custom" [...]`.
+
+If you don't mention this infix, `linuxdeployqt` won't be able to detect Qt Core and Widgets libraries.
+
 ## Using linuxdeployqt with Travis CI
 
 A common use case for `linuxdeployqt` is to use it on Travis CI after the `make` command. The following example illustrates how to use `linuxdeployqt` with Travis CI. Create a `.travis.yml` file similar to this one (be sure to customize it, e.g., change `APPNAME` to the name of your application as it is spelled in the `Name=` entry of the `.desktop` file):

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Usage examples:
 
 If you prepared a custom Qt distribution using the option `-qtlibinfix` during Qt configuration, you must mention this infix on `linuxdeployqt` call. As an example, let's see if we configure our distribution using the infix `Custom`.
 
-On Qt build chain: `configure -qtlibinfix "Custom" [...]`. This will generate Qt libraries (.so) like `Qt5CoreCustom.so`
+On Qt build chain: `configure -qtlibinfix "Custom" [...]`. This will generate Qt libraries (.so) like `libQt5CoreCustom.so`
 
 So, on `linuxdeployqt` call: `linuxdeployqt [...] -qtlibinfix "Custom" [...]`.
 

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
     extern QStringList ignoreGlob;
     extern bool copyCopyrightFiles;
     extern QString updateInformation;
+    extern QString qtLibInfix;
 
     // Check arguments
     // Due to the structure of the argument parser, we have to check all arguments at first to check whether the user
@@ -173,6 +174,10 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             updateInformation = QString(argument.mid(index+1));
+        } else if (argument.startsWith("-qtlibinfix=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            qtLibInfix = QString(argument.mid(index+1));
         } else if (argument.startsWith("--")) {
             LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;
@@ -231,6 +236,7 @@ int main(int argc, char **argv)
         qInfo() << "   -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                              2 = normal, 3 = debug.";
         qInfo() << "   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file";
+        qInfo() << "   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -64,6 +64,7 @@ QStringList excludeLibs;
 QStringList ignoreGlob;
 bool copyCopyrightFiles = true;
 QString updateInformation;
+QString qtLibInfix;
 
 using std::cout;
 using std::endl;
@@ -1010,12 +1011,12 @@ DeploymentInfo deployQtLibraries(QList<LibraryInfo> libraries,
         const LibraryInfo library = libraries.takeFirst();
         copiedLibraries.append(library.libraryName);
 
-        if(library.libraryName.contains("libQt") and library.libraryName.contains("Core.so")) {
+        if(library.libraryName.contains("libQt") and library.libraryName.contains("Core" + qtLibInfix + ".so")) {
             LogNormal() << "Setting deploymentInfo.qtPath to:" << library.libraryDirectory;
             deploymentInfo.qtPath = library.libraryDirectory;
         }
 
-        if(library.libraryName.contains("libQt") and library.libraryName.contains("Widgets.so")) {
+        if(library.libraryName.contains("libQt") and library.libraryName.contains("Widgets" + qtLibInfix + ".so")) {
             deploymentInfo.requiresQtWidgetsLibrary = true;
         }
 


### PR DESCRIPTION
In our company, we built a custom Qt distribution where all .so libraries are suffixed. This patch provides the ability to set this suffix in order to help linuxqtdeploy to find Qt plugins directory. Without it, **deploymentInfo.qtPath** struct field remains empty and **deployPlugins()** function is not called.
The argument exposed is **-qtlibinfix** like the Qt build chain.