### PR TITLE
Bundle appimagetool properly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TRAVIS_BUILD_NUMBER: ${{ github.run_number }}
       VERSION: continuous
+      APPIMAGE_EXTRACT_AND_RUN: 1
     steps:
       - name: Configure build machine
         run: |

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -55,6 +55,7 @@ ulimit -a -H
 set +e
 
 # print version number (need to extract the AppImage because we are running in a container, see https://github.com/AppImage/AppImageKit/wiki/FUSE#docker)
+export LD_LIBRARY_PATH=/tmp/appimagetool.AppDir/usr/lib
 ./linuxdeployqt-*-x86_64.AppImage --appimage-extract-and-run --version
 
 # TODO: reactivate tests

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -25,7 +25,7 @@ cp /usr/bin/{patchelf,desktop-file-validate} linuxdeployqt.AppDir/usr/bin/
 cp ./bin/linuxdeployqt linuxdeployqt.AppDir/usr/bin/
 cp -R /tmp/appimagekit.AppDir linuxdeployqt.AppDir/usr/appimagekit
 pushd linuxdeployqt.AppDir/usr/bin
-ln -s appimagetool ../appimagekit/AppRun
+ln -s ../appimagekit/AppRun appimagetool
 popd
 chmod +x linuxdeployqt.AppDir/AppRun
 find linuxdeployqt.AppDir/

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -23,7 +23,10 @@ set -e
 mkdir -p linuxdeployqt.AppDir/usr/{bin,lib}
 cp /usr/bin/{patchelf,desktop-file-validate} /usr/local/bin/{appimagetool,zsyncmake} linuxdeployqt.AppDir/usr/bin/
 cp ./bin/linuxdeployqt linuxdeployqt.AppDir/usr/bin/
-cp -r /usr/local/lib/appimagekit linuxdeployqt.AppDir/usr/lib/
+cp -R /tmp/appimagekit.AppDir linuxdeployqt.AppDir/usr/appimagekit
+pushd linuxdeploy.AppDir/usr/bin
+ln -s appimagetool ../appimagekit/AppRun
+popd
 chmod +x linuxdeployqt.AppDir/AppRun
 find linuxdeployqt.AppDir/
 if [ -z "$VERSION" ] ; then export VERSION=continuous ; fi

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -24,7 +24,7 @@ mkdir -p linuxdeployqt.AppDir/usr/{bin,lib}
 cp /usr/bin/{patchelf,desktop-file-validate} linuxdeployqt.AppDir/usr/bin/
 cp ./bin/linuxdeployqt linuxdeployqt.AppDir/usr/bin/
 cp -R /tmp/appimagekit.AppDir linuxdeployqt.AppDir/usr/appimagekit
-pushd linuxdeploy.AppDir/usr/bin
+pushd linuxdeployqt.AppDir/usr/bin
 ln -s appimagetool ../appimagekit/AppRun
 popd
 chmod +x linuxdeployqt.AppDir/AppRun

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -55,7 +55,7 @@ ulimit -a -H
 set +e
 
 # print version number (need to extract the AppImage because we are running in a container, see https://github.com/AppImage/AppImageKit/wiki/FUSE#docker)
-export LD_LIBRARY_PATH=/tmp/appimagetool.AppDir/usr/lib
+export LD_LIBRARY_PATH=/tmp/appimagekit.AppDir/usr/lib
 ./linuxdeployqt-*-x86_64.AppImage --appimage-extract-and-run --version
 
 # TODO: reactivate tests

--- a/tests/tests-ci.sh
+++ b/tests/tests-ci.sh
@@ -21,7 +21,7 @@ make -j$(nproc)
 set -e
 
 mkdir -p linuxdeployqt.AppDir/usr/{bin,lib}
-cp /usr/bin/{patchelf,desktop-file-validate} /usr/local/bin/{appimagetool,zsyncmake} linuxdeployqt.AppDir/usr/bin/
+cp /usr/bin/{patchelf,desktop-file-validate} linuxdeployqt.AppDir/usr/bin/
 cp ./bin/linuxdeployqt linuxdeployqt.AppDir/usr/bin/
 cp -R /tmp/appimagekit.AppDir linuxdeployqt.AppDir/usr/appimagekit
 pushd linuxdeploy.AppDir/usr/bin

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -17,14 +17,13 @@ sudo dpkg -i patchelf_0.8-2_amd64.deb
 # make -j$(nproc)
 # sudo make install
 
-cd /tmp/
+pushd /tmp/
 # wget -c https://artifacts.assassinate-you.net/artifactory/AppImageKit/travis-2052/appimagetool-x86_64.AppImage # branch last-good, https://travis-ci.org/AppImage/AppImageKit/jobs/507462541
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 chmod +x appimagetool*AppImage
-./appimagetool*AppImage --appimage-extract
-sudo cp squashfs-root/usr/bin/* /usr/local/bin/
-sudo cp -r squashfs-root/usr/lib/appimagekit /usr/local/lib/
-sudo chmod +rx /usr/local/lib/appimagekit
-cd -
+./appimagetool*AppImage --appimag-extract
+mv squashfs-root/ appimagekit.AppDir/
+export PATH="$(readlink -f appimagekit.AppDir/)":"$PATH"
+popd
 
 sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse psmisc qt59translations

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -17,8 +17,6 @@ sudo dpkg -i patchelf_0.8-2_amd64.deb
 # make -j$(nproc)
 # sudo make install
 
-sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse libfuse2 psmisc qt59translations
-
 pushd /tmp/
 # wget -c https://artifacts.assassinate-you.net/artifactory/AppImageKit/travis-2052/appimagetool-x86_64.AppImage # branch last-good, https://travis-ci.org/AppImage/AppImageKit/jobs/507462541
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
@@ -27,3 +25,5 @@ chmod +x appimagetool*AppImage
 mv squashfs-root/ appimagekit.AppDir/
 sudo ln -s "$(readlink -f appimagekit.AppDir/AppRun)" /usr/bin/appimagetool
 popd
+
+sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev psmisc qt59translations

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -17,6 +17,8 @@ sudo dpkg -i patchelf_0.8-2_amd64.deb
 # make -j$(nproc)
 # sudo make install
 
+sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse libfuse2 psmisc qt59translations
+
 pushd /tmp/
 # wget -c https://artifacts.assassinate-you.net/artifactory/AppImageKit/travis-2052/appimagetool-x86_64.AppImage # branch last-good, https://travis-ci.org/AppImage/AppImageKit/jobs/507462541
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
@@ -25,5 +27,3 @@ chmod +x appimagetool*AppImage
 mv squashfs-root/ appimagekit.AppDir/
 sudo ln -s "$(readlink -f appimagekit.AppDir/AppRun)" /usr/bin/appimagetool
 popd
-
-sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse libfuse2 psmisc qt59translations

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -23,7 +23,7 @@ wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/ap
 chmod +x appimagetool*AppImage
 ./appimagetool*AppImage --appimag-extract
 mv squashfs-root/ appimagekit.AppDir/
-export PATH="$(readlink -f appimagekit.AppDir/)":"$PATH"
+sudo ln -s "$(readlink -f appimagekit.AppDir/AppRun)" /usr/bin/appimagetool
 popd
 
-sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse psmisc qt59translations
+sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse libfuse2 psmisc qt59translations

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -21,7 +21,7 @@ pushd /tmp/
 # wget -c https://artifacts.assassinate-you.net/artifactory/AppImageKit/travis-2052/appimagetool-x86_64.AppImage # branch last-good, https://travis-ci.org/AppImage/AppImageKit/jobs/507462541
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 chmod +x appimagetool*AppImage
-./appimagetool*AppImage --appimag-extract
+./appimagetool*AppImage --appimage-extract
 mv squashfs-root/ appimagekit.AppDir/
 sudo ln -s "$(readlink -f appimagekit.AppDir/AppRun)" /usr/bin/appimagetool
 popd


### PR DESCRIPTION
This PR illustrates how to properly bundle appimagetool by bundling its entire AppDir and using `AppRun` as the entrypoint.

After playing CI ping-pong for 10 times (because this repository's CI is in a really bad state), please anyone feel free to use my work and finish it. I can't invest more time into debugging what linuxdeployqt is doing there. `LD_LIBRARY_PATH` has been set correctly IMO.

This will be the last ever contribution to this tool. It's obviously close to being unmaintained, and there are better alternatives out there. Contributing stuff is hard because of the bad state of CI and code as well.

Fixes #542.