### PR TITLE
Add Qt6WebEngine support

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1554,7 +1554,8 @@ void deployPlugins(const AppDirInfo &appDirInfo, const QString &pluginSourcePath
     // from the Qt instance that is to be bundled (pull requests welcome!)
     // especially since stuff that is supposed to come from resources actually
     // seems to come in libexec in the upstream Qt binary distribution
-    if (containsHowOften(deploymentInfo.deployedLibraries, "libQt5WebEngineCore")) {
+    if (containsHowOften(deploymentInfo.deployedLibraries, "libQt5WebEngineCore")
+        || containsHowOften(deploymentInfo.deployedLibraries, "libQt6WebEngineCore")) {
         // Find directories with needed files:
         QString qtLibexecPath = qtToBeBundledInfo.value("QT_INSTALL_LIBEXECS");
         QString qtDataPath = qtToBeBundledInfo.value("QT_INSTALL_DATA");


### PR DESCRIPTION
In Qt6WebEngine, as with Qt5WebEngine, it is necessary to copy resources and the executable binary.

I tested creating an AppImage for my application on Ubuntu 20.04 with Qt 6.5.2 using the following command:
`./linuxdeployqt AppDir/usr/share/applications/myapp.desktop -appimage -exclude-libs="libnss3.so,libnssutil3.so"`
(Note that tests/QtWebEngineApplication couldn't be built with Qt 6.5.2)

I appreciate your work. Thank you!