### PR TITLE
Add missing Categories for generating default.desktop file

### DIFF
--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1973,6 +1973,7 @@ bool checkAppImagePrerequisites(const QString &appDirPath)
         out << "Icon=default\n";
         out << "Comment=Edit this default file\n";
         out << "Terminal=true\n";
+        out << "Categories=Utility;\n";
         file.close();
     }
 


### PR DESCRIPTION
Hi,

We've got this error while using linuxdeployqt without desktop file :

```
linuxdeployqt  (commit 6fcaf74), build 55 built on 2023-09-23 13:33:41 UTC
WARNING: Not checking glibc on the host system.
         The resulting AppDir or AppImage may not run on older systems.
         This mode is unsupported and discouraged.
         For more information, please see
         https://github.com/probonopd/linuxdeployqt/issues/340
Not using FHS-like mode
app-binary: "~/my_project/install/app/my_application/my_application"
appDirPath: "~/my_project/install/app/my_application"
relativeBinPath: "my_application"
ERROR: Desktop file missing, creating a default one (you will probably want to edit it)
ERROR: Icon file missing, creating a default one (you will probably want to edit it)
appimagetool, continuous build (commit 8bbf694), build <local dev build> built on 2020-12-31 11:48:33 UTC
NOTE: Using the output of 'git rev-parse --short HEAD' as the version:
      16c130f
      Please set the $VERSION environment variable if this is not intended
Desktop file: ~/my_project/install/app/my_application/default.desktop
Categories entry not found in desktop file
.desktop file is missing a Categories= key
```