### PR TITLE
Allow recursive folder addition of executables (closes #379)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@ If you just would like to bundle your application for x86_64 platforms, it is no
 
 So, if you are on another platform (e.g. i686, ARM) or would like to compile from source, here are the steps:
 
-* Get and build linuxdeployqt e.g., using Qt 5.7.0 (you could use this [Qt Creator AppImage](https://bintray.com/probono/AppImages/QtCreator#files) for this)
+* Get and build linuxdeployqt e.g., using Qt 5.7.0 (before you could use this [Qt Creator AppImage](https://bintray.com/probono/AppImages/QtCreator#files) for this, but it is no longer available)
 
 ```
 sudo apt-get -y install git g++ libgl1-mesa-dev
@@ -22,7 +22,7 @@ make
 sudo make install
 ```
 
-* Build and install [patchelf](https://nixos.org/patchelf.html) (a small utility to modify the dynamic linker and RPATH of ELF executables; similar to `install_name_tool` on macOS). To learn more about this, see http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
+* Build and install [patchelf](https://nixos.org/patchelf.html) (a small utility to modify the dynamic linker and RPATH of ELF executables; similar to `install_name_tool` on macOS). To learn more about this, see http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/. Also available as Debian package `patchelf`.
 
 ```
 wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@ If you just would like to bundle your application for x86_64 platforms, it is no
 
 So, if you are on another platform (e.g. i686, ARM) or would like to compile from source, here are the steps:
 
-* Get and build linuxdeployqt e.g., using Qt 5.7.0 (before you could use this [Qt Creator AppImage](https://bintray.com/probono/AppImages/QtCreator#files) for this, but it is no longer available)
+* Get and build linuxdeployqt
 
 ```
 sudo apt-get -y install git g++ libgl1-mesa-dev

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Options:
                               searching for libraries.
    -executable=<path>       : Let the given executable use the deployed libraries
                               too
+   -executable-dir=<path>   : Let all the executables in the folder (recursive) use
+                              the deployed libraries too
    -extra-plugins=<list>    : List of extra plugins which should be deployed,
                               separated by comma.
    -no-copy-copyright-files : Skip deployment of copyright files.


### PR DESCRIPTION
Thanks for making linuxdeployqt available.

The issue referenced is rather old and the current solution used in the inkscape packaging (using a `for` loop in shell scripting) might be all needed.

This patch adds a `-executable-dir` command-line that adds all files in a folder, recursively.

Supporting wildcards might need additional dependencies and doesn't seem worth making the code more complex.

Note: the build instructions reference to an AppImage on bintray.com that is no longer available. It might be worth posting an alternative someplace else. It builds find with system Qt Creator.
 