### PR TITLE
Fix build with Qt6

### DIFF
--- a/tools/linuxdeployqt/CMakeLists.txt
+++ b/tools/linuxdeployqt/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions("-DBUILD_DATE=\"${DATE}\"")
 add_definitions("-DBUILD_NUMBER=\"${BUILD_NUMBER}\"")
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 
 # update excludelist
 message(STATUS "Updating excludelist...")


### PR DESCRIPTION
find_package(QT ...) only finds out if Qt5 or Qt6 is available. One needs to then to find_package(Qt5...) or find_package(Qt6...) as in the Qt documentation:
https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html

Otherwise, one gets this error:
CMake Error: AUTOMOC for target linuxdeployqt: Could not find moc executable target Qt6::moc CMake Generate step failed.  Build files cannot be regenerated correctly.