### PR TITLE
Add option -runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Options:
    -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),
                               2 = normal, 3 = debug.
    -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file
+   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.
+   -runtime==<path>         : Runtime file to use. (-runtime=<path>/runtime)
    -version                 : Print version statement and exit.
 
 linuxdeployqt takes an application as input and makes it

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options:
                               2 = normal, 3 = debug.
    -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file
    -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.
-   -runtime==<path>         : Runtime file to use. (-runtime=<path>/runtime)
+   -runtime-file=<path>         : Runtime file to use. (-runtime-file=<path>/runtime)
    -version                 : Print version statement and exit.
 
 linuxdeployqt takes an application as input and makes it

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Options:
    -show-exclude-libs       : Print exclude libraries list.
    -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),
                               2 = normal, 3 = debug.
-   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file
+   -updateinformation=<update string>        : Embed update information STRING;
+                              if zsyncmake is installed, generate zsync file
    -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.
-   -runtime-file=<path>         : Runtime file to use. (-runtime-file=<path>/runtime)
+   -runtime-file=<path>     : Runtime file to use. (-runtime-file=<path>/runtime)
    -version                 : Print version statement and exit.
 
 linuxdeployqt takes an application as input and makes it

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -76,6 +76,7 @@ int main(int argc, char **argv)
     extern bool copyCopyrightFiles;
     extern QString updateInformation;
     extern QString qtLibInfix;
+    extern QString runtime;
 
     // Check arguments
     // Due to the structure of the argument parser, we have to check all arguments at first to check whether the user
@@ -186,7 +187,11 @@ int main(int argc, char **argv)
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             qtLibInfix = QString(argument.mid(index+1));
-        } else if (argument.startsWith("--")) {
+        } else if (argument.startsWith("-runtime=")) {
+            LogDebug() << "Argument found:" << argument;
+            int index = argument.indexOf("=");
+            runtime = QString(argument.mid(index+1));
+        }else if (argument.startsWith("--")) {
             LogError() << "Error: arguments must not start with --, only -:" << argument << "\n";
             return 1;
         } else {
@@ -252,6 +257,7 @@ int main(int argc, char **argv)
         qInfo() << "                              2 = normal, 3 = debug.";
         qInfo() << "   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file";
         qInfo() << "   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.";
+        qInfo() << "   -runtime==<path>         : Runtime file to use. (-runtime=<path>/runtime)";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -255,7 +255,8 @@ int main(int argc, char **argv)
         qInfo() << "   -show-exclude-libs       : Print exclude libraries list.";
         qInfo() << "   -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                              2 = normal, 3 = debug.";
-        qInfo() << "   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file";
+        qInfo() << "   -updateinformation=<update string>        : Embed update information STRING;
+                                                  if zsyncmake is installed, generate zsync file";
         qInfo() << "   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.";
         qInfo() << "   -runtime-file=<path>     : Runtime file to use. (-runtime-file=<path>/runtime)";
         qInfo() << "   -version                 : Print version statement and exit.";

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     extern QStringList ignoreGlob;
     extern bool copyCopyrightFiles;
     extern QString updateInformation;
-    extern QString qtLibInfix;
+    extern QString qtLibfix;
     extern QString runtime;
 
     // Check arguments
@@ -186,8 +186,8 @@ int main(int argc, char **argv)
         } else if (argument.startsWith("-qtlibinfix=")) {
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
-            qtLibInfix = QString(argument.mid(index+1));
-        } else if (argument.startsWith("-runtime=")) {
+            qtLibfix = QString(argument.mid(index+1));
+        } else if (argument.startsWith("-runtime-file=")) {
             LogDebug() << "Argument found:" << argument;
             int index = argument.indexOf("=");
             runtime = QString(argument.mid(index+1));
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
     }
     
     // We need to catch those errors at the source of the problem
-    // https://github.com/AppImage/appimage.github.io/search?q=GLIBC&unscoped_q=GLIBC&type=Issues
+    // https://github.com/appimage.github.io/search?q=GLIBC&unscoped_q=GLIBC&type=Issues
     const char *glcv = gnu_get_libc_version ();
     if(skipGlibcCheck) {
         if(! bundleEverything) {
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
         qInfo() << "                              2 = normal, 3 = debug.";
         qInfo() << "   -updateinformation=<update string>        : Embed update information STRING; if zsyncmake is installed, generate zsync file";
         qInfo() << "   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.";
-        qInfo() << "   -runtime==<path>         : Runtime file to use. (-runtime=<path>/runtime)";
+        qInfo() << "   -runtime-file=<path>     : Runtime file to use. (-runtime-file=<path>/runtime)";
         qInfo() << "   -version                 : Print version statement and exit.";
         qInfo() << "";
         qInfo() << "linuxdeployqt takes an application as input and makes it";

--- a/tools/linuxdeployqt/main.cpp
+++ b/tools/linuxdeployqt/main.cpp
@@ -255,8 +255,8 @@ int main(int argc, char **argv)
         qInfo() << "   -show-exclude-libs       : Print exclude libraries list.";
         qInfo() << "   -verbose=<0-3>           : 0 = no output, 1 = error/warning (default),";
         qInfo() << "                              2 = normal, 3 = debug.";
-        qInfo() << "   -updateinformation=<update string>        : Embed update information STRING;
-                                                  if zsyncmake is installed, generate zsync file";
+        qInfo() << "   -updateinformation=<update string>        : Embed update information STRING;";
+        qInfo() << "                              if zsyncmake is installed, generate zsync file";
         qInfo() << "   -qtlibinfix=<infix>      : Adapt the .so search if your Qt distribution has infix.";
         qInfo() << "   -runtime-file=<path>     : Runtime file to use. (-runtime-file=<path>/runtime)";
         qInfo() << "   -version                 : Print version statement and exit.";

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -70,6 +70,7 @@ QStringList ignoreGlob;
 bool copyCopyrightFiles = true;
 QString updateInformation;
 QString qtLibInfix;
+QString runtime;
 
 using std::cout;
 using std::endl;
@@ -1977,6 +1978,7 @@ bool checkAppImagePrerequisites(const QString &appDirPath)
         out << "Icon=default\n";
         out << "Comment=Edit this default file\n";
         out << "Terminal=true\n";
+        out << "# Categories=Development\n";
         file.close();
     }
 
@@ -2006,7 +2008,12 @@ int createAppImage(const QString &appDirPath)
         updateInfoArgument = QString("-u '%1'").arg(updateInformation);
     }
 
-    QString appImageCommand = "appimagetool -v '" + appDirPath + "' -n " + updateInfoArgument; // +"' '" + appImagePath + "'";
+    QString runtimeArgument;
+    if(!runtime.isEmpty()) {
+        runtimeArgument = QString(" --runtime-file %1").arg(runtime);
+    }
+
+    QString appImageCommand = "appimagetool -v '" + appDirPath + "' -n " + updateInfoArgument + runtimeArgument; // +"' '" + appImagePath + "'";
     LogNormal() << appImageCommand;
     int ret = system(appImageCommand.toUtf8().constData());
     LogNormal() << "ret" << ret;

--- a/tools/linuxdeployqt/shared.cpp
+++ b/tools/linuxdeployqt/shared.cpp
@@ -1978,7 +1978,7 @@ bool checkAppImagePrerequisites(const QString &appDirPath)
         out << "Icon=default\n";
         out << "Comment=Edit this default file\n";
         out << "Terminal=true\n";
-        out << "# Categories=Development\n";
+        out << "Categories=Development\n";
         file.close();
     }
 


### PR DESCRIPTION
Using the -runtime option to specify the runtime file path is more friendly to developers in offline development environments and poor network environments.