### PR TITLE
sort behave differently under different distributions (Ubuntu, WSL)

### DIFF
--- a/tools/generate-excludelist.sh
+++ b/tools/generate-excludelist.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Download excludelist
-blacklisted=($(wget --quiet https://raw.githubusercontent.com/probonopd/AppImages/master/excludelist -O - | sort | uniq | cut -d '#' -f 1 | grep -v "^#.*" | grep "[^-\s]"))
+blacklisted=($(wget --quiet https://raw.githubusercontent.com/probonopd/AppImages/master/excludelist -O - | LC_ALL=C sort -f | uniq | cut -d '#' -f 1 | grep -v "^#.*" | grep "[^-\s]"))
 
 # Sanity check
 if [ "$blacklisted" == "" ]; then


### PR DESCRIPTION
according to the manual, sort order is impacted by the locale specified by the environment.
To get a stable sorted list of exclude files, need to change the sort command parameters.