### PR TITLE
Add arm64 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,11 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
-    container: ubuntu:xenial
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
+    container: ubuntu:bionic
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TRAVIS_BUILD_NUMBER: ${{ github.run_number }}

--- a/tests/tests-environment.sh
+++ b/tests/tests-environment.sh
@@ -2,15 +2,21 @@
 
 set -e
 
-sudo add-apt-repository --yes ppa:beineri/opt-qt593-xenial
 sudo apt-get update -qq
 
 # wget https://ftp.fau.de/debian/pool/main/p/patchelf/patchelf_0.8-2_amd64.deb
 # echo "5d506507df7c02766ae6c3ca0d15b4234f4cb79a80799190ded9d3ca0ac28c0c  patchelf_0.8-2_amd64.deb" | sha256sum -c
-wget http://old-releases.ubuntu.com/ubuntu/pool/universe/p/patchelf/patchelf_0.8-2_amd64.deb
-echo "b3b69f346afb16ab9e925b91afc4c77179a70b676c2eb58a2821f8664fd4cae6  patchelf_0.8-2_amd64.deb" | sha256sum -c
+if [ "$(uname -m)" = "aarch64" ]; then
+  wget http://old-releases.ubuntu.com/ubuntu/pool/universe/p/patchelf/patchelf_0.8-2_arm64.deb;
+  echo "3236b6aa89e891a9ab2da4f4574784b29ebd418b55d30a332ed8e2feff537d3c  patchelf_0.8-2_arm64.deb" | sha256sum -c;
+  tool_arch="aarch64";
+else
+  wget http://old-releases.ubuntu.com/ubuntu/pool/universe/p/patchelf/patchelf_0.8-2_amd64.deb;
+  echo "b3b69f346afb16ab9e925b91afc4c77179a70b676c2eb58a2821f8664fd4cae6  patchelf_0.8-2_amd64.deb" | sha256sum -c;
+  tool_arch="x86_64";
+fi
 
-sudo dpkg -i patchelf_0.8-2_amd64.deb
+sudo dpkg -i patchelf_0.8-2_*.deb
 # We want a newer patchelf since the one above is missing e.g., '--add-needed' which our users might want to use
 # However, the newer patchelf versions are broken and cripple, e.g., libQt5Core; see https://github.com/NixOS/patchelf/issues/124
 # git clone -o e1e39f3 https://github.com/NixOS/patchelf
@@ -23,7 +29,7 @@ sudo dpkg -i patchelf_0.8-2_amd64.deb
 cd /tmp/
 # wget -c https://artifacts.assassinate-you.net/artifactory/AppImageKit/travis-2052/appimagetool-x86_64.AppImage # branch last-good, https://travis-ci.org/AppImage/AppImageKit/jobs/507462541
 # wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" # See #542
-wget -c "https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage" # Workaround for #542
+wget -c "https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-$tool_arch.AppImage" # Workaround for #542
 chmod +x appimagetool*AppImage
 ./appimagetool*AppImage --appimage-extract
 sudo cp squashfs-root/usr/bin/* /usr/local/bin/
@@ -31,4 +37,4 @@ sudo cp -r squashfs-root/usr/lib/appimagekit /usr/local/lib/
 sudo chmod +rx /usr/local/lib/appimagekit
 cd -
 
-sudo apt-get -y install qt59base qt59declarative qt59webengine binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse psmisc qt59translations
+sudo apt-get -y install qt5-default qtbase5-dev qtdeclarative5-dev qtwebengine5-dev qttranslations5-l10n binutils xpra zsync desktop-file-utils gcc g++ make libgl1-mesa-dev fuse psmisc


### PR DESCRIPTION
I'm not sure why are you using `container: ubuntu:xenial` (trusty will reach End of Life in [April 2026](https://wiki.ubuntu.com/Releases)).
Since you are using Qt 5.9 and it's not aviable via ppa for xenial for arm64: I decided to add arm64 build using `container: ubuntu:bionic` while keeping `container: ubuntu:xenial` for amd64 version.

If you have any comments, please write and ping me.